### PR TITLE
Fix: PHPUnit error handler crash inside OpenSwoole coroutines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
     - name: Upload coverage reports to Codecov
       if: matrix.dependency-version == 'prefer-stable' && matrix.php-version == '8.4'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         files: ./reports/coverage/clover.xml
         flags: php-${{ matrix['php-version'] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Upload coverage reports to Codecov
       if: matrix.dependency-version == 'prefer-stable' && matrix.php-version == '8.3'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         file: ./reports/coverage/clover.xml
         flags: php-${{ matrix['php-version'] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,20 @@ jobs:
         php-version: ['8.2', '8.3', '8.4', '8.5']
     steps:
     - uses: actions/checkout@v6
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Build and save Docker image
-      run: |
-        docker build --build-arg PHP_VERSION=${{ matrix.php-version }} -t openswoole-bundle:${{ matrix.php-version }} .
-        docker save openswoole-bundle:${{ matrix.php-version }} | gzip > openswoole-bundle-${{ matrix.php-version }}.tar.gz
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        build-args: PHP_VERSION=${{ matrix.php-version }}
+        tags: openswoole-bundle:${{ matrix.php-version }}
+        cache-from: type=gha,scope=php-${{ matrix.php-version }}
+        cache-to: type=gha,scope=php-${{ matrix.php-version }},mode=max
+        outputs: type=docker,dest=openswoole-bundle-${{ matrix.php-version }}.tar.gz
+
     - name: Upload Docker image
       uses: actions/upload-artifact@v7
       with:
@@ -76,44 +86,36 @@ jobs:
 
   static-analysis:
     runs-on: ubuntu-latest
-    needs: build
     name: Static Analysis
 
     steps:
     - uses: actions/checkout@v6
 
-    - name: Download Docker image
-      uses: actions/download-artifact@v8
+    - uses: shivammathur/setup-php@v2
       with:
-        name: openswoole-bundle-image-8.4
-
-    - name: Load Docker image
-      run: docker load < openswoole-bundle-8.4.tar.gz
+        php-version: '8.4'
+        coverage: none
 
     - name: Install dependencies
-      run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.4 composer install --prefer-dist --no-interaction --ignore-platform-reqs
+      run: composer install --prefer-dist --no-interaction --ignore-platform-reqs
 
     - name: Run PHPStan
-      run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.4 bin/phpstan analyse --error-format=github --memory-limit=-1
+      run: bin/phpstan analyse --error-format=github --memory-limit=-1
 
   code-style:
     runs-on: ubuntu-latest
-    needs: build
     name: Code Style
 
     steps:
     - uses: actions/checkout@v6
 
-    - name: Download Docker image
-      uses: actions/download-artifact@v8
+    - uses: shivammathur/setup-php@v2
       with:
-        name: openswoole-bundle-image-8.4
-
-    - name: Load Docker image
-      run: docker load < openswoole-bundle-8.4.tar.gz
+        php-version: '8.4'
+        coverage: none
 
     - name: Install dependencies
-      run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.4 composer install --prefer-dist --no-interaction --ignore-platform-reqs
+      run: composer install --prefer-dist --no-interaction --ignore-platform-reqs
 
     - name: Run PHP CS Fixer
-      run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.4 bin/php-cs-fixer fix --dry-run --diff --verbose
+      run: bin/php-cs-fixer fix --dry-run --diff --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Upload coverage reports to Codecov
       if: matrix.dependency-version == 'prefer-stable' && matrix.php-version == '8.4'
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@v5
       with:
         file: ./reports/coverage/clover.xml
         flags: php-${{ matrix['php-version'] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,36 +86,44 @@ jobs:
 
   static-analysis:
     runs-on: ubuntu-latest
+    needs: build
     name: Static Analysis
 
     steps:
     - uses: actions/checkout@v6
 
-    - uses: shivammathur/setup-php@v2
+    - name: Download Docker image
+      uses: actions/download-artifact@v8
       with:
-        php-version: '8.4'
-        coverage: none
+        name: openswoole-bundle-image-8.4
+
+    - name: Load Docker image
+      run: docker load < openswoole-bundle-8.4.tar.gz
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-interaction --ignore-platform-reqs
+      run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.4 composer install --prefer-dist --no-interaction --ignore-platform-reqs
 
     - name: Run PHPStan
-      run: bin/phpstan analyse --error-format=github --memory-limit=-1
+      run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.4 bin/phpstan analyse --error-format=github --memory-limit=-1
 
   code-style:
     runs-on: ubuntu-latest
+    needs: build
     name: Code Style
 
     steps:
     - uses: actions/checkout@v6
 
-    - uses: shivammathur/setup-php@v2
+    - name: Download Docker image
+      uses: actions/download-artifact@v8
       with:
-        php-version: '8.4'
-        coverage: none
+        name: openswoole-bundle-image-8.4
+
+    - name: Load Docker image
+      run: docker load < openswoole-bundle-8.4.tar.gz
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-interaction --ignore-platform-reqs
+      run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.4 composer install --prefer-dist --no-interaction --ignore-platform-reqs
 
     - name: Run PHP CS Fixer
-      run: bin/php-cs-fixer fix --dry-run --diff --verbose
+      run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.4 bin/php-cs-fixer fix --dry-run --diff --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
       matrix:
         php-version: ['8.2', '8.3', '8.4']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Build and save Docker image
       run: |
         docker build --build-arg PHP_VERSION=${{ matrix.php-version }} -t openswoole-bundle:${{ matrix.php-version }} .
         docker save openswoole-bundle:${{ matrix.php-version }} | gzip > openswoole-bundle-${{ matrix.php-version }}.tar.gz
     - name: Upload Docker image
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: openswoole-bundle-image-${{ matrix.php-version }}
         path: openswoole-bundle-${{ matrix.php-version }}.tar.gz
@@ -40,12 +40,12 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
     - name: Download Docker image
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: openswoole-bundle-image-${{ matrix.php-version }}
 
@@ -80,10 +80,10 @@ jobs:
     name: Static Analysis
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Download Docker image
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: openswoole-bundle-image-8.3
 
@@ -102,10 +102,10 @@ jobs:
     name: Code Style
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Download Docker image
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: openswoole-bundle-image-8.3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build and save Docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         build-args: PHP_VERSION=${{ matrix.php-version }}
@@ -76,7 +76,7 @@ jobs:
       if: matrix.dependency-version == 'prefer-stable' && matrix.php-version == '8.4'
       uses: codecov/codecov-action@v5
       with:
-        file: ./reports/coverage/clover.xml
+        files: ./reports/coverage/clover.xml
         flags: php-${{ matrix['php-version'] }}
         name: phpunit-${{ matrix['php-version'] }}
         fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.2', '8.3', '8.4', '8.5']
     steps:
     - uses: actions/checkout@v6
     - name: Build and save Docker image
@@ -30,7 +30,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.2', '8.3', '8.4', '8.5']
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: Test PHP ${{ matrix.php-version }} - ${{ matrix.dependency-version }}
@@ -59,11 +59,11 @@ jobs:
       run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:${{ matrix.php-version }} composer test:run
 
     - name: Run tests with coverage
-      if: matrix.dependency-version == 'prefer-stable' && matrix.php-version == '8.3'
+      if: matrix.dependency-version == 'prefer-stable' && matrix.php-version == '8.4'
       run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:${{ matrix.php-version }} composer test:coverage
 
     - name: Upload coverage reports to Codecov
-      if: matrix.dependency-version == 'prefer-stable' && matrix.php-version == '8.3'
+      if: matrix.dependency-version == 'prefer-stable' && matrix.php-version == '8.4'
       uses: codecov/codecov-action@v6
       with:
         file: ./reports/coverage/clover.xml
@@ -85,16 +85,16 @@ jobs:
     - name: Download Docker image
       uses: actions/download-artifact@v8
       with:
-        name: openswoole-bundle-image-8.3
+        name: openswoole-bundle-image-8.4
 
     - name: Load Docker image
-      run: docker load < openswoole-bundle-8.3.tar.gz
+      run: docker load < openswoole-bundle-8.4.tar.gz
 
     - name: Install dependencies
-      run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.3 composer install --prefer-dist --no-interaction --ignore-platform-reqs
+      run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.4 composer install --prefer-dist --no-interaction --ignore-platform-reqs
 
     - name: Run PHPStan
-      run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.3 bin/phpstan analyse --error-format=github --memory-limit=-1
+      run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.4 bin/phpstan analyse --error-format=github --memory-limit=-1
 
   code-style:
     runs-on: ubuntu-latest
@@ -113,7 +113,7 @@ jobs:
       run: docker load < openswoole-bundle-8.3.tar.gz
 
     - name: Install dependencies
-      run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.3 composer install --prefer-dist --no-interaction --ignore-platform-reqs
+      run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.4 composer install --prefer-dist --no-interaction --ignore-platform-reqs
 
     - name: Run PHP CS Fixer
-      run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.3 bin/php-cs-fixer fix --dry-run --diff --verbose
+      run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.4 bin/php-cs-fixer fix --dry-run --diff --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,10 @@ jobs:
     - name: Download Docker image
       uses: actions/download-artifact@v8
       with:
-        name: openswoole-bundle-image-8.3
+        name: openswoole-bundle-image-8.4
 
     - name: Load Docker image
-      run: docker load < openswoole-bundle-8.3.tar.gz
+      run: docker load < openswoole-bundle-8.4.tar.gz
 
     - name: Install dependencies
       run: docker run --rm -v ${{ github.workspace }}:/var/www/project openswoole-bundle:8.4 composer install --prefer-dist --no-interaction --ignore-platform-reqs

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -12,7 +12,7 @@ $finder = PhpCsFixer\Finder::create()
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
-        '@PER-CS2.0' => true,
+        '@PER-CS2x0' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
         'concat_space' => ['spacing' => 'one'],

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -8,5 +8,5 @@ parameters:
     bootstrapFiles:
         - vendor/autoload.php
     ignoreErrors:
-        - '#Parameter \#1 \$server of method Upscale\\\\Swoole\\\\Blackfire\\\\Profiler::instrument\(\) expects Swoole\\\\Http\\\\Server, OpenSwoole\\\\Http\\\\Server\|null given\.#'
+        - '#Profiler::instrument\(\) expects Swoole#'
 

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -7,6 +7,3 @@ parameters:
         - vendor
     bootstrapFiles:
         - vendor/autoload.php
-    ignoreErrors:
-        - '#Profiler::instrument\(\) expects Swoole#'
-

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -7,5 +7,4 @@ parameters:
         - vendor
     bootstrapFiles:
         - vendor/autoload.php
-    ignoreErrors:
-        - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\)#'
+

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -7,4 +7,6 @@ parameters:
         - vendor
     bootstrapFiles:
         - vendor/autoload.php
+    ignoreErrors:
+        - '#Parameter \#1 \$server of method Upscale\\\\Swoole\\\\Blackfire\\\\Profiler::instrument\(\) expects Swoole\\\\Http\\\\Server, OpenSwoole\\\\Http\\\\Server\|null given\.#'
 

--- a/src/Batch/BatchRunner.php
+++ b/src/Batch/BatchRunner.php
@@ -138,9 +138,8 @@ final class BatchRunner
         } finally {
             $this->setPrevHookFlags();
             restore_error_handler();
+            $this->eventDispatcher?->dispatch(new BatchRunnerEnded($this));
         }
-
-        $this->eventDispatcher?->dispatch(new BatchRunnerEnded($this));
     }
 
     private function startWaitGroup(): void

--- a/src/Batch/BatchRunner.php
+++ b/src/Batch/BatchRunner.php
@@ -182,8 +182,13 @@ final class BatchRunner
         $eventDispatcher = $this->eventDispatcher;
         $batchRunner = $this;
 
-        return static function () use ($resultChannel, $key, $callable, $eventDispatcher, $batchRunner): void {
+        $previousErrorHandler = $this->captureCurrentErrorHandler();
+
+        return static function () use ($resultChannel, $key, $callable, $eventDispatcher, $batchRunner, $previousErrorHandler): void {
             $eventDispatcher?->dispatch(new BatchRunnerItemStarted($batchRunner, (string) $key));
+
+            // Replace PHPUnit's error handler for the duration of the callable.
+            set_error_handler($previousErrorHandler ?? static fn () => false);
 
             try {
                 $result = Result::fromValue($callable());
@@ -197,6 +202,8 @@ final class BatchRunner
                 $eventDispatcher?->dispatch(
                     new BatchRunnerItemEndedWithException($batchRunner, (string) $key, $e),
                 );
+            } finally {
+                restore_error_handler();
             }
             $resultChannel->push([$key, $result]);
         };
@@ -214,6 +221,23 @@ final class BatchRunner
         if ($this->setRuntimeHooks) {
             Runtime::setHookFlags($this->prevHookFlags);
         }
+    }
+
+    /**
+     * Captures the currently active error handler without replacing it.
+     *
+     * PHPUnit registers its own error handler that traverses the call stack via
+     * debug_backtrace() to find the TestCase object. Inside an OpenSwoole coroutine
+     * the call stack no longer contains the TestCase, which causes
+     * NoTestCaseObjectOnCallStackException. By temporarily replacing the error
+     * handler with the one active before PHPUnit's, we avoid the crash.
+     */
+    private function captureCurrentErrorHandler(): callable|null
+    {
+        $handler = set_error_handler(static fn () => false);
+        restore_error_handler();
+
+        return $handler;
     }
 
     private function ensureNotStarted(): void

--- a/src/Batch/BatchRunner.php
+++ b/src/Batch/BatchRunner.php
@@ -182,13 +182,8 @@ final class BatchRunner
         $eventDispatcher = $this->eventDispatcher;
         $batchRunner = $this;
 
-        $previousErrorHandler = $this->captureCurrentErrorHandler();
-
-        return static function () use ($resultChannel, $key, $callable, $eventDispatcher, $batchRunner, $previousErrorHandler): void {
+        return static function () use ($resultChannel, $key, $callable, $eventDispatcher, $batchRunner): void {
             $eventDispatcher?->dispatch(new BatchRunnerItemStarted($batchRunner, (string) $key));
-
-            // Replace PHPUnit's error handler for the duration of the callable.
-            set_error_handler($previousErrorHandler ?? static fn () => false);
 
             try {
                 $result = Result::fromValue($callable());
@@ -202,8 +197,6 @@ final class BatchRunner
                 $eventDispatcher?->dispatch(
                     new BatchRunnerItemEndedWithException($batchRunner, (string) $key, $e),
                 );
-            } finally {
-                restore_error_handler();
             }
             $resultChannel->push([$key, $result]);
         };
@@ -221,23 +214,6 @@ final class BatchRunner
         if ($this->setRuntimeHooks) {
             Runtime::setHookFlags($this->prevHookFlags);
         }
-    }
-
-    /**
-     * Captures the currently active error handler without replacing it.
-     *
-     * PHPUnit registers its own error handler that traverses the call stack via
-     * debug_backtrace() to find the TestCase object. Inside an OpenSwoole coroutine
-     * the call stack no longer contains the TestCase, which causes
-     * NoTestCaseObjectOnCallStackException. By temporarily replacing the error
-     * handler with the one active before PHPUnit's, we avoid the crash.
-     */
-    private function captureCurrentErrorHandler(): callable|null
-    {
-        $handler = set_error_handler(static fn () => false);
-        restore_error_handler();
-
-        return $handler;
     }
 
     private function ensureNotStarted(): void

--- a/src/Batch/BatchRunner.php
+++ b/src/Batch/BatchRunner.php
@@ -125,10 +125,9 @@ final class BatchRunner
         $this->eventDispatcher?->dispatch(new BatchRunnerStarted($this));
         $this->started = true;
 
-        $this->setHookFlags();
-
         $previousErrorHandler = $this->captureCurrentErrorHandler();
         set_error_handler($previousErrorHandler ?? static fn () => false);
+        $this->setHookFlags();
 
         try {
             if (CoroutineHelper::inCoroutine()) {
@@ -137,10 +136,9 @@ final class BatchRunner
                 $this->startScheduler();
             }
         } finally {
+            $this->setPrevHookFlags();
             restore_error_handler();
         }
-
-        $this->setPrevHookFlags();
 
         $this->eventDispatcher?->dispatch(new BatchRunnerEnded($this));
     }

--- a/src/Batch/BatchRunner.php
+++ b/src/Batch/BatchRunner.php
@@ -132,9 +132,11 @@ final class BatchRunner
         try {
             if (CoroutineHelper::inCoroutine()) {
                 $this->startWaitGroup();
-            } else {
-                $this->startScheduler();
+
+                return;
             }
+
+            $this->startScheduler();
         } finally {
             $this->setPrevHookFlags();
             restore_error_handler();

--- a/src/Batch/BatchRunner.php
+++ b/src/Batch/BatchRunner.php
@@ -127,10 +127,17 @@ final class BatchRunner
 
         $this->setHookFlags();
 
-        if (CoroutineHelper::inCoroutine()) {
-            $this->startWaitGroup();
-        } else {
-            $this->startScheduler();
+        $previousErrorHandler = $this->captureCurrentErrorHandler();
+        set_error_handler($previousErrorHandler ?? static fn () => false);
+
+        try {
+            if (CoroutineHelper::inCoroutine()) {
+                $this->startWaitGroup();
+            } else {
+                $this->startScheduler();
+            }
+        } finally {
+            restore_error_handler();
         }
 
         $this->setPrevHookFlags();
@@ -182,13 +189,8 @@ final class BatchRunner
         $eventDispatcher = $this->eventDispatcher;
         $batchRunner = $this;
 
-        $previousErrorHandler = $this->captureCurrentErrorHandler();
-
-        return static function () use ($resultChannel, $key, $callable, $eventDispatcher, $batchRunner, $previousErrorHandler): void {
+        return static function () use ($resultChannel, $key, $callable, $eventDispatcher, $batchRunner): void {
             $eventDispatcher?->dispatch(new BatchRunnerItemStarted($batchRunner, (string) $key));
-
-            // Replace PHPUnit's error handler for the duration of the callable.
-            set_error_handler($previousErrorHandler ?? static fn () => false);
 
             try {
                 $result = Result::fromValue($callable());
@@ -202,8 +204,6 @@ final class BatchRunner
                 $eventDispatcher?->dispatch(
                     new BatchRunnerItemEndedWithException($batchRunner, (string) $key, $e),
                 );
-            } finally {
-                restore_error_handler();
             }
             $resultChannel->push([$key, $result]);
         };

--- a/src/Command/ReloadCommand.php
+++ b/src/Command/ReloadCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class ReloadCommand extends ServerCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('openswoole:server:reload')

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 class StartCommand extends ServerCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('openswoole:server:start')

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class StatusCommand extends ServerCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('openswoole:server:status')

--- a/src/Command/StopCommand.php
+++ b/src/Command/StopCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class StopCommand extends ServerCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('openswoole:server:stop')
             ->setDescription('Stop OpenSwoole HTTP Server.')

--- a/src/DependencyInjection/CompilerPass/DoctrineCleanerSubscriberPass.php
+++ b/src/DependencyInjection/CompilerPass/DoctrineCleanerSubscriberPass.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class DoctrineCleanerSubscriberPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         foreach (['doctrine_mongodb', 'doctrine'] as $definitionId) {
             if ($container->hasDefinition($definitionId)) {

--- a/src/DependencyInjection/CompilerPass/SentryPublisherSubscriberPass.php
+++ b/src/DependencyInjection/CompilerPass/SentryPublisherSubscriberPass.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class SentryPublisherSubscriberPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->hasDefinition('Sentry\ClientInterface')) {
             $definition = new Definition(SentryPublisherSubscriber::class);

--- a/src/DependencyInjection/OpenSwooleExtension.php
+++ b/src/DependencyInjection/OpenSwooleExtension.php
@@ -23,7 +23,7 @@ class OpenSwooleExtension extends Extension
      *
      * @throws \Exception
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader($container, new FileLocator(dirname(__DIR__) . '/Resources/config'));
         $loader->load('services.yaml');

--- a/src/EventSubscriber/AMQPReconnectSubscriber.php
+++ b/src/EventSubscriber/AMQPReconnectSubscriber.php
@@ -32,7 +32,7 @@ final readonly class AMQPReconnectSubscriber implements EventSubscriberInterface
     /**
      * @throws \Exception
      */
-    public function onKernelException(ExceptionEvent $event)
+    public function onKernelException(ExceptionEvent $event): void
     {
         if ($event->getThrowable() instanceof AMQPExceptionInterface) {
             $this->server->stopWorker();

--- a/tests/TestCase/BatchRunner/BatchRunnerMockIntegrationTest.php
+++ b/tests/TestCase/BatchRunner/BatchRunnerMockIntegrationTest.php
@@ -25,7 +25,8 @@ final class BatchRunnerMockIntegrationTest extends TestCase
         $mock = $this->createMock(SomeServiceInterface::class);
         $mock->expects(self::once())
             ->method('fetch')
-            ->willReturn(['item1', 'item2']);
+            ->willReturn(['item1', 'item2'])
+        ;
 
         $results = BatchRunner::fromCallables([
             static fn () => $mock->fetch(),
@@ -39,12 +40,14 @@ final class BatchRunnerMockIntegrationTest extends TestCase
         $mockA = $this->createMock(SomeServiceInterface::class);
         $mockA->expects(self::once())
             ->method('fetch')
-            ->willReturn('result-a');
+            ->willReturn('result-a')
+        ;
 
         $mockB = $this->createMock(SomeServiceInterface::class);
         $mockB->expects(self::once())
             ->method('fetch')
-            ->willReturn('result-b');
+            ->willReturn('result-b')
+        ;
 
         $results = BatchRunner::fromCallables([
             'a' => static fn () => $mockA->fetch(),

--- a/tests/TestCase/BatchRunner/BatchRunnerMockIntegrationTest.php
+++ b/tests/TestCase/BatchRunner/BatchRunnerMockIntegrationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSwooleBundle\Tests\TestCase\BatchRunner;
+
+use OpenSwooleBundle\Batch\BatchRunner;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies that PHPUnit mock objects can be used inside BatchRunner coroutines.
+ *
+ * PHPUnit (>=11.5.49) registers a custom error handler that traverses the call stack
+ * via debug_backtrace() to locate the TestCase instance. Inside an OpenSwoole coroutine
+ * the call stack is separate, so the TestCase is not found and
+ * NoTestCaseObjectOnCallStackException is thrown.
+ *
+ * BatchRunner now captures the previous error handler and restores it inside each
+ * coroutine, preventing the crash.
+ */
+final class BatchRunnerMockIntegrationTest extends TestCase
+{
+    public function testMockCanBeInvokedInsideCoroutine(): void
+    {
+        $mock = $this->createMock(SomeServiceInterface::class);
+        $mock->expects(self::once())
+            ->method('fetch')
+            ->willReturn(['item1', 'item2']);
+
+        $results = BatchRunner::fromCallables([
+            static fn () => $mock->fetch(),
+        ])->runAll();
+
+        self::assertSame([['item1', 'item2']], $results);
+    }
+
+    public function testMultipleMocksInParallelCoroutines(): void
+    {
+        $mockA = $this->createMock(SomeServiceInterface::class);
+        $mockA->expects(self::once())
+            ->method('fetch')
+            ->willReturn('result-a');
+
+        $mockB = $this->createMock(SomeServiceInterface::class);
+        $mockB->expects(self::once())
+            ->method('fetch')
+            ->willReturn('result-b');
+
+        $results = BatchRunner::fromCallables([
+            'a' => static fn () => $mockA->fetch(),
+            'b' => static fn () => $mockB->fetch(),
+        ])->runAll();
+
+        self::assertSame('result-a', $results['a']);
+        self::assertSame('result-b', $results['b']);
+    }
+}
+
+interface SomeServiceInterface
+{
+    public function fetch(): mixed;
+}

--- a/tests/TestCase/BatchRunner/BatchRunnerTest.php
+++ b/tests/TestCase/BatchRunner/BatchRunnerTest.php
@@ -254,6 +254,42 @@ final class BatchRunnerTest extends TestCase
         ];
     }
 
+    public function testErrorHandlerIsRestoredAfterRun(): void
+    {
+        $customHandler = static fn () => false;
+        set_error_handler($customHandler);
+
+        try {
+            BatchRunner::fromCallables([static fn () => 'ok'])->runAll();
+
+            $activeHandler = set_error_handler(static fn () => false);
+            restore_error_handler();
+
+            self::assertSame($customHandler, $activeHandler);
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    public function testErrorHandlerIsRestoredAfterException(): void
+    {
+        $customHandler = static fn () => false;
+        set_error_handler($customHandler);
+
+        try {
+            BatchRunner::fromCallables([static function () {
+                throw new \RuntimeException('fail');
+            }])->runAll();
+        } catch (\Throwable) {
+        } finally {
+            $activeHandler = set_error_handler(static fn () => false);
+            restore_error_handler();
+            restore_error_handler();
+        }
+
+        self::assertSame($customHandler, $activeHandler);
+    }
+
     public static function createCallablesWithException(): array
     {
         return [

--- a/tests/TestCase/DependencyInjection/OpenSwooleExtensionTest.php
+++ b/tests/TestCase/DependencyInjection/OpenSwooleExtensionTest.php
@@ -139,7 +139,7 @@ final class OpenSwooleExtensionTest extends TestCase
     }
 
     #[DataProvider('providerLoad')]
-    public function testLoad(array $config, array $assertServices, array $expected)
+    public function testLoad(array $config, array $assertServices, array $expected): void
     {
         $extension = new OpenSwooleExtension();
         $containerBuilder = new ContainerBuilder();

--- a/tests/TestCase/OpenSwooleBundleTest.php
+++ b/tests/TestCase/OpenSwooleBundleTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class OpenSwooleBundleTest extends TestCase
 {
-    public function testBuild()
+    public function testBuild(): void
     {
         $containerBuilder = new ContainerBuilder();
         $bundle = new OpenSwooleBundle();


### PR DESCRIPTION
### Problem                                                                                                                                                                        
                                                                                                                                                                                     
  PHPUnit ≥11.5.49 registers a custom error handler that uses `debug_backtrace()` to locate the `TestCase` instance on the call stack. Inside OpenSwoole coroutines, the call stack is separate and doesn't contain the `TestCase` object, causing `NoTestCaseObjectOnCallStackException` whenever a PHPUnit mock triggers an error-level event (e.g. deprecation, notice) inside a coroutine.                                                                                                                                                        
                                                                                                                                                                                     
  ### Solution                                                                                                                                                                       
                                                                                                                                                                                     
  `BatchRunner::start()` now temporarily replaces the active error handler with the previous one before entering coroutines, and restores it in a `finally` block. This prevents PHPUnit's handler from traversing a coroutine call stack where `TestCase` doesn't exist.                                                                                           
                                                                                                                                                                                     
  Additionally, all cleanup logic (`setPrevHookFlags`, `restore_error_handler`, `BatchRunnerEnded` event dispatch) is now wrapped in `finally` to guarantee proper resource cleanup even when coroutines throw exceptions.                                                                                                                                             
                                                                                                                                                                                     
  ### Other changes                                                                                                                                                                  
                                                                                                                                                                                     
  - Added `void` return types to methods missing them (Commands, CompilerPasses, Extension, Subscriber)                                                                              
  - Removed obsolete PHPStan `ignoreErrors` entry                                                                                                                                    
  - CI: added PHP 8.5 to test matrix, bumped GitHub Actions versions, switched to Docker Buildx with GHA caching, moved static analysis/code style to PHP 8.4                        
                                                 